### PR TITLE
Test with custom mbedtls3 on flatpak

### DIFF
--- a/CI/flatpak/com.obsproject.Studio.json
+++ b/CI/flatpak/com.obsproject.Studio.json
@@ -194,8 +194,8 @@
         {
           "type": "git",
           "url": "https://github.com/ARMmbed/mbedtls.git",
-          "commit": "1c54b5410fd48d6bcada97e30cac417c5c7eea67",
-          "tag": "v2.25.0"
+          "commit": "8df2f8e7b9c7bb9390ac74bb7bace27edca81a2b",
+          "tag": "v3.0.0"
         }
       ]
     },

--- a/plugins/obs-outputs/librtmp/rtmp.c
+++ b/plugins/obs-outputs/librtmp/rtmp.c
@@ -954,7 +954,11 @@ RTMP_Connect1(RTMP *r, RTMPPacket *cp)
 
 #if defined(USE_MBEDTLS)
         mbedtls_net_context *server_fd = &r->RTMP_TLS_ctx->net;
+#if MBEDTLS_VERSION_NUMBER == 0x03000000
+        server_fd->MBEDTLS_PRIVATE(fd) = r->m_sb.sb_socket;
+#else
         server_fd->fd = r->m_sb.sb_socket;
+#endif
         TLS_setfd(r->m_sb.sb_ssl, server_fd);
 
         // make sure we verify the certificate hostname
@@ -1540,7 +1544,7 @@ ReadN(RTMP *r, char *buffer, int n)
         if (r->Link.protocol & RTMP_FEATURE_HTTP)
             r->m_resplen -= nBytes;
 
-#ifdef CRYPTO
+#if defined(CRYPTO) && (!defined(USE_MBEDTLS) || MBEDTLS_VERSION_MAJOR < 3)
         if (r->Link.rc4keyIn)
         {
             RC4_encrypt(r->Link.rc4keyIn, nBytes, ptr);
@@ -1562,6 +1566,7 @@ WriteN(RTMP *r, const char *buffer, int n)
     char *encrypted = 0;
     char buf[RTMP_BUFFER_CACHE_SIZE];
 
+#if !defined(USE_MBEDTLS) || MBEDTLS_VERSION_MAJOR < 3
     if (r->Link.rc4keyOut)
     {
         if (n > (int)sizeof(buf))
@@ -1571,6 +1576,7 @@ WriteN(RTMP *r, const char *buffer, int n)
         ptr = encrypted;
         RC4_encrypt2(r->Link.rc4keyOut, n, buffer, ptr);
     }
+#endif
 #endif
 
     while (n > 0)
@@ -2602,7 +2608,7 @@ b64enc(const unsigned char *input, int length, char *output, int maxsize)
 #if defined(USE_MBEDTLS)
 typedef	mbedtls_md5_context MD5_CTX;
 
-#if MBEDTLS_VERSION_NUMBER >= 0x02070000
+#if MBEDTLS_VERSION_NUMBER >= 0x02070000 && MBEDTLS_VERSION_MAJOR < 3
 #define MD5_Init(ctx)	mbedtls_md5_init(ctx); mbedtls_md5_starts_ret(ctx)
 #define MD5_Update(ctx,data,len)	mbedtls_md5_update_ret(ctx,(unsigned char *)data,len)
 #define MD5_Final(dig,ctx)	mbedtls_md5_finish_ret(ctx,dig); mbedtls_md5_free(ctx)
@@ -4404,7 +4410,7 @@ RTMP_Close(RTMP *r)
         free(r->Link.tcUrl.av_val);
         r->Link.tcUrl.av_val = NULL;
     }
-#elif defined(CRYPTO)
+#elif defined(CRYPTO) && (!defined(USE_MBEDTLS) || MBEDTLS_VERSION_MAJOR < 3)
     if (r->Link.dh)
     {
         MDH_free(r->Link.dh);

--- a/plugins/obs-outputs/librtmp/rtmp.h
+++ b/plugins/obs-outputs/librtmp/rtmp.h
@@ -338,9 +338,11 @@ extern "C"
 
 #ifdef CRYPTO
 #define RTMP_SWF_HASHLEN	32
+#if !defined(USE_MBEDTLS) || MBEDTLS_VERSION_MAJOR < 3
         void *dh;			/* for encryption */
         void *rc4keyIn;
         void *rc4keyOut;
+#endif
 
         uint32_t SWFSize;
         uint8_t SWFHash[RTMP_SWF_HASHLEN];


### PR DESCRIPTION
## Description
Mbedtls 3 is out since July and some rolling release distro can update to it at any moment, so I tried to make OBS compatible with it. It also make OBS unable to manage encrypted RTMP (not RTMPS) with mbedtls 3 since it don't support the RC4 algorithms anymore.

~~From the [migration guide](https://github.com/ARMmbed/mbedtls/blob/development/docs/3.0-migration-guide.md#most-structure-fields-are-now-private) I quote:~~

~~>If no accessor function exists, please open an enhancement request against Mbed TLS and describe your use case. The Mbed TLS development team is aware that some useful accessor functions are missing in the 3.0 release, and we expect to add them to the first minor release(s) (3.1, etc.).~~

~~Why I quote that ? We need an accessor to set the file descriptor of the the socket inside the net context of mbedtls, see [here](https://github.com/tytan652/obs-studio/blob/test_mbedtls3/plugins/obs-outputs/librtmp/rtmp.c#L957).~~

~~So I made this commit https://github.com/tytan652/mbedtls/commit/37bac90f2424d01a84c05cb6aa7eee9ad5eac0ad to add it and see if it works.~~

~~If it works I will make a PR to [mbedtls repo](https://github.com/ARMmbed/mbedtls) with this [branch](https://github.com/tytan652/mbedtls/tree/set_fd).~~

**A PR has merged so `fd` need a special behavior for only 3.0.0.**

I made this PR to provide flatpak artifacts build with the modified mbedtls to make you test it.

To test it, you will need to stream to platform which use RTMPS protocol (YouTube, Facebook) because this the one affected by this change.

**Only flatpak is valid because this is the only artifact who can be easily build with different dependencies.**

## How to get the flatpak
1. Go to the check tab
![Artifact_1](https://user-images.githubusercontent.com/17492366/129085088-071e3490-25ac-4e49-a118-5f4453bb747d.png)
2. Go to Flatpak (Experimental)
![Artifact_2](https://user-images.githubusercontent.com/17492366/129085105-3d032a7a-e647-4740-a41f-7cf7b766d13d.png)
3. Select the artifact on the page (the name of the file can change)
![Artifact_3](https://user-images.githubusercontent.com/17492366/129085118-488ae4cf-dcb5-454a-ae36-47da3c38a0ad.png)
4. Extract the flatpak from the artifact archive
5. Install the flatpak
```sh
flatpak install --bundle <name-of-the-file>.flatpak
```
6. Launch it
```sh
flatpak run com.obsproject.Studio
```
7. Test to live with RTMPS

- Note: To uninstall it, it's this command: 
```sh
flatpak uninstall com.obsproject.Studio
```

