### PR TITLE
Gbsneto/flathub changes

### DIFF
--- a/.github/actions/flatpak-builder-lint/action.yaml
+++ b/.github/actions/flatpak-builder-lint/action.yaml
@@ -7,6 +7,10 @@ inputs:
   path:
     description: Path to flatpak-builder manifest or Flatpak build directory
     required: true
+  validateToPublish:
+    description: If false, turns some errors to non-errors for non-publish workflow
+    required: false
+    default: true
   workingDirectory:
     description: Working directory to clone flatpak-builder-lint
     required: false
@@ -65,9 +69,15 @@ runs:
         done
 
         n_errors=$(echo $ret | jq '.errors | length')
-        for ((i = 0; i < $n_errors; i++)); do
+        for ((i = 0 ; i < $(echo $ret | jq '.errors | length') ; i++)); do
           error=$(echo $ret | jq ".errors[$i]")
-          echo "::error::$error found in the Flatpak ${{ inputs.artifact }}"
+
+          if [[ "${{ inputs.validateToPublish }}" == "false" && "${error//\"}" == "appstream-screenshots-not-mirrored" ]]; then
+            echo "::notice::$error found and ignored in the Flatpak ${{ inputs.artifact }}"
+            n_errors=$(($n_errors-1))
+          else
+            echo "::error::$error found in the Flatpak ${{ inputs.artifact }}"
+          fi
         done
 
         [[ $n_errors == 0 ]] || exit 2

--- a/.github/actions/flatpak-builder-lint/action.yaml
+++ b/.github/actions/flatpak-builder-lint/action.yaml
@@ -1,0 +1,73 @@
+name: Run flatpak-builder-lint
+description: Runs flatpak-builder-lint with exceptions
+inputs:
+  artifact:
+    description: Type of artifact to lint (builddir, repo, manifest)
+    required: true
+  path:
+    description: Path to flatpak-builder manifest or Flatpak build directory
+    required: true
+  workingDirectory:
+    description: Working directory to clone flatpak-builder-lint
+    required: false
+    default: ${{ github.workspace }}
+runs:
+  using: composite
+  steps:
+    - name: Check artifact type
+      shell: bash
+      working-directory: ${{ inputs.workingDirectory }}
+      run: |
+        : Check artifact input
+        case "${{ inputs.artifact }}" in
+          builddir);;
+          repo);;
+          manifest);;
+          *)
+            echo "::error::Given artifact type is incorrect"
+            exit 2
+            ;;
+        esac
+
+    - uses: actions/checkout@v3
+      with:
+        repository: flathub/flatpak-builder-lint
+        ref: v2.0.13
+        path: flatpak-builder-lint
+        set-safe-directory: ${{ inputs.workingDirectory }}
+
+    - name: Install Dependencies 🛍️
+      shell: bash
+      working-directory: ${{ inputs.workingDirectory }}
+      run: |
+        : Install Dependencies 🛍️
+        echo ::group::Install Dependencies
+        dnf install -y -q poetry jq
+        poetry -q -C flatpak-builder-lint install
+        echo ::endgroup::
+
+    - name: Run flatpak-builder-lint
+      id: result
+      shell: bash
+      working-directory: ${{ inputs.workingDirectory }}
+      run: |
+        : Run flatpak-builder-lint
+        exit_code=0
+        ret=$(poetry -C flatpak-builder-lint run flatpak-builder-lint --exceptions ${{ inputs.artifact }} ${{ inputs.path }}) || exit_code=$?
+        if [[ $exit_code != 0 && -z "$ret" ]]; then
+          echo "::error::Error while running flatpak-builder-lint"
+          exit 2
+        fi
+
+        for ((i = 0 ; i < $(echo $ret | jq '.warnings | length') ; i++)); do
+          warning=$(echo $ret | jq ".warnings[$i]")
+          echo "::warning::$warning found in the Flatpak ${{ inputs.artifact }}"
+        done
+
+        n_errors=$(echo $ret | jq '.errors | length')
+        for ((i = 0; i < $n_errors; i++)); do
+          error=$(echo $ret | jq ".errors[$i]")
+          echo "::error::$error found in the Flatpak ${{ inputs.artifact }}"
+        done
+
+        [[ $n_errors == 0 ]] || exit 2

--- a/.github/workflows/build-project.yaml
+++ b/.github/workflows/build-project.yaml
@@ -291,6 +291,7 @@ jobs:
         with:
           artifact: manifest
           path: build-aux/com.obsproject.Studio.json
+          validateToPublish: false
 
       - name: Build Flatpak Manifest 🧾
         uses: flatpak/flatpak-github-actions/flatpak-builder@0ab9dd6a6afa6fe7e292db0325171660bf5b6fdf
@@ -307,6 +308,7 @@ jobs:
         with:
           artifact: builddir
           path: flatpak_app
+          validateToPublish: false
 
   windows-build:
     name: Windows 🪟

--- a/.github/workflows/build-project.yaml
+++ b/.github/workflows/build-project.yaml
@@ -287,7 +287,7 @@ jobs:
           echo "cacheKey=${cache_key}" >> $GITHUB_OUTPUT
 
       - name: Build Flatpak Manifest 🧾
-        uses: flatpak/flatpak-github-actions/flatpak-builder@1283416d7c0462e052ab0685d9444a7a48bfff3b
+        uses: flatpak/flatpak-github-actions/flatpak-builder@0ab9dd6a6afa6fe7e292db0325171660bf5b6fdf
         with:
           build-bundle: ${{ fromJSON(needs.check-event.outputs.package) }}
           bundle: obs-studio-flatpak-${{ needs.check-event.outputs.commitHash }}.flatpak

--- a/.github/workflows/build-project.yaml
+++ b/.github/workflows/build-project.yaml
@@ -286,6 +286,12 @@ jobs:
 
           echo "cacheKey=${cache_key}" >> $GITHUB_OUTPUT
 
+      - name: Validate Flatpak manifest
+        uses: ./.github/actions/flatpak-builder-lint
+        with:
+          artifact: manifest
+          path: build-aux/com.obsproject.Studio.json
+
       - name: Build Flatpak Manifest 🧾
         uses: flatpak/flatpak-github-actions/flatpak-builder@0ab9dd6a6afa6fe7e292db0325171660bf5b6fdf
         with:
@@ -295,6 +301,12 @@ jobs:
           cache: ${{ fromJSON(steps.setup.outputs.cacheHit) || (github.event_name == 'push' && github.ref_name == 'master')}}
           restore-cache: ${{ fromJSON(steps.setup.outputs.cacheHit) }}
           cache-key: ${{ steps.setup.outputs.cacheKey }}
+
+      - name: Validate build directory
+        uses: ./.github/actions/flatpak-builder-lint
+        with:
+          artifact: builddir
+          path: flatpak_app
 
   windows-build:
     name: Windows 🪟

--- a/.github/workflows/build-project.yaml
+++ b/.github/workflows/build-project.yaml
@@ -310,6 +310,13 @@ jobs:
           path: flatpak_app
           validateToPublish: false
 
+      - name: Validate repository
+        uses: ./.github/actions/flatpak-builder-lint
+        with:
+          artifact: repo
+          path: repo
+          validateToPublish: false
+
   windows-build:
     name: Windows 🪟
     runs-on: windows-2022

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -98,6 +98,12 @@ jobs:
           echo "cacheKey=${cache_key}" >> $GITHUB_OUTPUT
           echo "commitHash=${GITHUB_SHA:0:9}" >> $GITHUB_OUTPUT
 
+      - name: Validate Flatpak manifest
+        uses: ./.github/actions/flatpak-builder-lint
+        with:
+          artifact: manifest
+          path: build-aux/com.obsproject.Studio.json
+
       - name: Build Flatpak Manifest
         uses: flatpak/flatpak-github-actions/flatpak-builder@0ab9dd6a6afa6fe7e292db0325171660bf5b6fdf
         with:
@@ -125,6 +131,18 @@ jobs:
         run: |
           : Commit Screenshots to OSTree Repository
           ostree commit --repo=repo --canonical-permissions --branch=screenshots/x86_64 flatpak_app/screenshots
+
+      - name: Validate build directory
+        uses: ./.github/actions/flatpak-builder-lint
+        with:
+          artifact: builddir
+          path: flatpak_app
+
+      - name: Validate repository
+        uses: ./.github/actions/flatpak-builder-lint
+        with:
+          artifact: repo
+          path: repo
 
       - name: Publish to Flathub Beta
         uses: flatpak/flatpak-github-actions/flat-manager@0ab9dd6a6afa6fe7e292db0325171660bf5b6fdf

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -133,6 +133,7 @@ jobs:
           flat-manager-url: https://hub.flathub.org/
           repository: beta
           token: ${{ secrets.FLATHUB_BETA_TOKEN }}
+          build-log-url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
 
       - name: Publish to Flathub
         uses: flatpak/flatpak-github-actions/flat-manager@0ab9dd6a6afa6fe7e292db0325171660bf5b6fdf
@@ -141,6 +142,7 @@ jobs:
           flat-manager-url: https://hub.flathub.org/
           repository: stable
           token: ${{ secrets.FLATHUB_TOKEN }}
+          build-log-url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
 
   steam-upload:
     name: Upload Steam Builds 🚂

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -99,7 +99,7 @@ jobs:
           echo "commitHash=${GITHUB_SHA:0:9}" >> $GITHUB_OUTPUT
 
       - name: Build Flatpak Manifest
-        uses: flatpak/flatpak-github-actions/flatpak-builder@1283416d7c0462e052ab0685d9444a7a48bfff3b
+        uses: flatpak/flatpak-github-actions/flatpak-builder@0ab9dd6a6afa6fe7e292db0325171660bf5b6fdf
         with:
           bundle: obs-studio-${{ steps.setup.outputs.commitHash }}.flatpak
           manifest-path: ${{ github.workspace }}/build-aux/com.obsproject.Studio.json
@@ -127,7 +127,7 @@ jobs:
           ostree commit --repo=repo --canonical-permissions --branch=screenshots/x86_64 flatpak_app/screenshots
 
       - name: Publish to Flathub Beta
-        uses: flatpak/flatpak-github-actions/flat-manager@1283416d7c0462e052ab0685d9444a7a48bfff3b
+        uses: flatpak/flatpak-github-actions/flat-manager@0ab9dd6a6afa6fe7e292db0325171660bf5b6fdf
         if: ${{ matrix.branch == 'beta' }}
         with:
           flat-manager-url: https://hub.flathub.org/
@@ -135,7 +135,7 @@ jobs:
           token: ${{ secrets.FLATHUB_BETA_TOKEN }}
 
       - name: Publish to Flathub
-        uses: flatpak/flatpak-github-actions/flat-manager@1283416d7c0462e052ab0685d9444a7a48bfff3b
+        uses: flatpak/flatpak-github-actions/flat-manager@0ab9dd6a6afa6fe7e292db0325171660bf5b6fdf
         if: ${{ matrix.branch == 'stable' }}
         with:
           flat-manager-url: https://hub.flathub.org/

--- a/plugins/win-capture/graphics-hook-ver.h
+++ b/plugins/win-capture/graphics-hook-ver.h
@@ -13,7 +13,7 @@
 
 #define HOOK_VER_MAJOR 1
 #define HOOK_VER_MINOR 8
-#define HOOK_VER_PATCH 2
+#define HOOK_VER_PATCH 3
 
 #ifndef STRINGIFY
 #define STRINGIFY(s) #s


### PR DESCRIPTION
Difference with the original https://github.com/obsproject/obs-studio/pull/9776:

- Has https://github.com/obsproject/obs-studio/pull/9809 which make it pass validation
- Avoid the use of org.flatpak.Builder to use the linter since it does not to work. It relies on cloning the linter repo and using Poetry to run it
- Validation steps are factorized as a custom action
- Lint warnings and errors are reformatted as action warnings and errors
- Some customization were added to allow validating the Flatpak repo on pushes to avoid encountering an error only while on publish validation.